### PR TITLE
Ошибка при сохранении пустого одиночного свойства тип Файл

### DIFF
--- a/lib/orm/db/gateway/iblockelement.php
+++ b/lib/orm/db/gateway/iblockelement.php
@@ -435,7 +435,7 @@ class IblockElement extends Gateway {
             $DB->Query("
                 update
                 b_iblock_element_prop_s".$this->iblockId()."
-                set PROPERTY_".$propertyId."=".$fileId."
+                set PROPERTY_".$propertyId."=".($fileId ? : 'null')."
                 where IBLOCK_ELEMENT_ID=".$id."
             ");
             return ;


### PR DESCRIPTION
При сохранении пустого значения происходит ошибка в DB query, т.к PROPERTY_ид свойства = пустоте